### PR TITLE
Add user plan system with free tier limits

### DIFF
--- a/BACKEND/src/dao/short_url.js
+++ b/BACKEND/src/dao/short_url.js
@@ -6,6 +6,7 @@ export const saveShortUrl = async (
   longUrl,
   userId,
   ipAddress = null,
+  userPlan = null,
 ) => {
   try {
     const newUrl = new urlSchema({
@@ -14,10 +15,14 @@ export const saveShortUrl = async (
     });
     if (userId) {
       newUrl.user = userId;
+      // Set click limit for free users only
+      if (userPlan === "free") {
+        newUrl.click_limit = 10; // Free users have 10 click limit per URL
+      }
     }
     if (ipAddress && !userId) {
       newUrl.ip_address = ipAddress;
-      newUrl.click_limit = 10; // Free users have 10 click limit per URL
+      newUrl.click_limit = 10; // Anonymous users have 10 click limit per URL
     }
     await newUrl.save();
   } catch (err) {

--- a/BACKEND/src/dao/short_url.js
+++ b/BACKEND/src/dao/short_url.js
@@ -57,3 +57,7 @@ export const getCustomShortUrl = async (slug) => {
 export const getUrlCountByIpAddress = async (ipAddress) => {
   return await urlSchema.countDocuments({ ip_address: ipAddress });
 };
+
+export const getUrlCountByUser = async (userId) => {
+  return await urlSchema.countDocuments({ user: userId });
+};

--- a/BACKEND/src/models/user.model.js
+++ b/BACKEND/src/models/user.model.js
@@ -19,7 +19,13 @@ const userSchema = new mongoose.Schema({
   avatar: {
     type: String,
     required: false,
-    default: "https://www.gravatar.com/avatar/00000000000000000000000000000000?d=mp",
+    default:
+      "https://www.gravatar.com/avatar/00000000000000000000000000000000?d=mp",
+  },
+  plan: {
+    type: String,
+    enum: ["free", "premium"],
+    default: "free",
   },
 });
 
@@ -27,12 +33,12 @@ userSchema.methods.comparePassword = async function (password) {
   return await bcrypt.compare(password, this.password);
 };
 
-userSchema.set('toJSON', {
+userSchema.set("toJSON", {
   transform: function (doc, ret) {
     delete ret.password;
     delete ret.__v;
     return ret;
-  }
+  },
 });
 
 userSchema.pre("save", async function (next) {

--- a/BACKEND/src/services/short_url.service.js
+++ b/BACKEND/src/services/short_url.service.js
@@ -4,6 +4,7 @@ import {
   getCustomShortUrl,
   saveShortUrl,
   getUrlCountByIpAddress,
+  getUrlCountByUser,
 } from "../dao/short_url.js";
 
 export const createShortUrlWithoutUser = async (url, ipAddress) => {

--- a/BACKEND/src/services/short_url.service.js
+++ b/BACKEND/src/services/short_url.service.js
@@ -1,5 +1,6 @@
 import { generateNanoId } from "../utils/helper.js";
 import urlSchema from "../models/short_url.model.js";
+import User from "../models/user.model.js";
 import {
   getCustomShortUrl,
   saveShortUrl,

--- a/BACKEND/src/services/short_url.service.js
+++ b/BACKEND/src/services/short_url.service.js
@@ -24,12 +24,25 @@ export const createShortUrlWithoutUser = async (url, ipAddress) => {
 };
 
 export const createShortUrlWithUser = async (url, userId, slug = null) => {
+  // Check user's plan and URL count limit for free users
+  const user = await User.findById(userId);
+  if (!user) throw new Error("User not found");
+
+  if (user.plan === "free") {
+    const urlCount = await getUrlCountByUser(userId);
+    if (urlCount >= 5) {
+      throw new Error(
+        "Free users are limited to 5 short URLs. Please upgrade to premium for unlimited access.",
+      );
+    }
+  }
+
   const shortUrl = slug || generateNanoId(7);
   if (slug) {
     const exists = await getCustomShortUrl(slug);
     if (exists) throw new Error("This custom url already exists");
   }
 
-  await saveShortUrl(shortUrl, url, userId);
+  await saveShortUrl(shortUrl, url, userId, null, user.plan);
   return shortUrl;
 };


### PR DESCRIPTION
This change introduces a user plan system with different limits for free and premium users.

Changes made:
- Added `plan` field to user model with enum values "free" and "premium", defaulting to "free"
- Modified `saveShortUrl` function to accept `userPlan` parameter
- Updated click limit logic: free users get 10 clicks per URL, anonymous users get 10 clicks per URL
- Added `getUrlCountByUser` function to count URLs created by a specific user
- Implemented URL creation limit for free users (maximum 5 URLs)
- Added user plan validation in `createShortUrlWithUser` service
- Updated function calls to pass user plan information

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/f0fa0fe8b91f4fdb99d6dd060d432101/cosmos-home)

👀 [Preview Link](https://f0fa0fe8b91f4fdb99d6dd060d432101-cosmos-home.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>f0fa0fe8b91f4fdb99d6dd060d432101</projectId>-->
<!--<branchName>cosmos-home</branchName>-->