### PR TITLE
Remove free user limits, grant unlimited access to all users

### DIFF
--- a/BACKEND/src/dao/short_url.js
+++ b/BACKEND/src/dao/short_url.js
@@ -15,10 +15,7 @@ export const saveShortUrl = async (
     });
     if (userId) {
       newUrl.user = userId;
-      // Set click limit for free users only
-      if (userPlan === "free") {
-        newUrl.click_limit = 10; // Free users have 10 click limit per URL
-      }
+      // Logged in users have unlimited clicks (no click_limit set)
     }
     if (ipAddress && !userId) {
       newUrl.ip_address = ipAddress;

--- a/BACKEND/src/services/short_url.service.js
+++ b/BACKEND/src/services/short_url.service.js
@@ -24,18 +24,9 @@ export const createShortUrlWithoutUser = async (url, ipAddress) => {
 };
 
 export const createShortUrlWithUser = async (url, userId, slug = null) => {
-  // Check user's plan and URL count limit for free users
+  // Logged in users have unlimited access
   const user = await User.findById(userId);
   if (!user) throw new Error("User not found");
-
-  if (user.plan === "free") {
-    const urlCount = await getUrlCountByUser(userId);
-    if (urlCount >= 5) {
-      throw new Error(
-        "Free users are limited to 5 short URLs. Please upgrade to premium for unlimited access.",
-      );
-    }
-  }
 
   const shortUrl = slug || generateNanoId(7);
   if (slug) {

--- a/FRONTEND/src/components/UrlForm.jsx
+++ b/FRONTEND/src/components/UrlForm.jsx
@@ -52,7 +52,7 @@ const UrlForm = () => {
 
   return (
     <div className="space-y-6">
-      {(!isAuthenticated || (user && user.plan === "free")) && (
+      {!isAuthenticated && (
         <div className="p-4 bg-amber-50 border border-amber-200 rounded-lg">
           <div className="flex items-center">
             <svg
@@ -73,9 +73,35 @@ const UrlForm = () => {
                 Free User Limits
               </h3>
               <p className="text-amber-700 text-sm mt-1">
-                Free users can create up to 5 short URLs, each with a maximum of
-                10 clicks. {!isAuthenticated ? "Sign up" : "Upgrade to premium"}{" "}
-                for unlimited access!
+                Anonymous users can create up to 5 short URLs, each with a
+                maximum of 10 clicks. Sign up for unlimited access!
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+      {isAuthenticated && (
+        <div className="p-4 bg-green-50 border border-green-200 rounded-lg">
+          <div className="flex items-center">
+            <svg
+              className="w-5 h-5 text-green-600 mr-3"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="2"
+                d="M5 13l4 4L19 7"
+              />
+            </svg>
+            <div>
+              <h3 className="text-green-800 font-medium text-sm">
+                Unlimited Access
+              </h3>
+              <p className="text-green-700 text-sm mt-1">
+                As a logged-in user, you have unlimited URL creation and clicks!
               </p>
             </div>
           </div>


### PR DESCRIPTION
This change removes all limitations for logged-in users and simplifies the user experience:

**Backend Changes:**
- Removed click limit enforcement for free users in short_url.js
- Removed URL count limit checks for free users in short_url.service.js
- Updated comments to reflect unlimited access for logged-in users

**Frontend Changes:**
- Updated warning banner to only show for anonymous users
- Added new success banner for authenticated users showing unlimited access
- Changed messaging from "Free User Limits" to focus on anonymous vs authenticated users

The system now treats all authenticated users equally with unlimited URL creation and clicks, while anonymous users retain the existing 5 URL / 10 click limits.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 5`

🔗 [Edit in Builder.io](https://builder.io/app/projects/f0fa0fe8b91f4fdb99d6dd060d432101/swoosh-verse)

👀 [Preview Link](https://f0fa0fe8b91f4fdb99d6dd060d432101-swoosh-verse.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>f0fa0fe8b91f4fdb99d6dd060d432101</projectId>-->
<!--<branchName>swoosh-verse</branchName>-->